### PR TITLE
Feat: 웹 페이지에서 이미지 태그 클릭 시 테두리 그리기 #5

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,5 +21,6 @@
     "typescript": "^4.6.3",
     "webpack": "^5.71.0",
     "webpack-cli": "^4.9.2"
-  }
+  },
+  "dependencies": {}
 }

--- a/client/src/content/index.ts
+++ b/client/src/content/index.ts
@@ -1,16 +1,80 @@
 const setup = () => {
+  addOnClickBodyToWindow();
+};
+
+const addOnClickBodyToWindow = () => {
   if (!window.onClickBody) {
     window.onClickBody = (e: MouseEvent) => {
       e.preventDefault();
       e.stopPropagation();
 
       const targetElement = e.target as HTMLImageElement;
-      console.log(targetElement.tagName === 'IMG');
+      console.log('Is targetElement Image? ' + targetElement.tagName === 'IMG');
       if (targetElement.tagName === 'IMG') {
         console.log(targetElement.currentSrc);
+        const { top, left, width, height } = targetElement.getBoundingClientRect();
+        resizeCanvas({ top, left, width, height });
+        drawRectCanvas();
+      } else {
+        clearCanvas();
       }
     };
   }
+};
+
+const createCanvas = () => {
+  const $body = document.querySelector('body');
+  const $canvas = document.createElement('canvas');
+  $canvas.id = 'imageReader';
+  $canvas.style.position = 'absolute';
+  $body?.insertAdjacentElement('afterbegin', $canvas);
+};
+
+const removeCanvas = () => {
+  const $body = document.querySelector('body');
+  const $canvas = document.querySelector('#imageReader');
+  if ($canvas) $body?.removeChild($canvas);
+};
+
+const resizeCanvas = ({
+  top,
+  left,
+  width,
+  height,
+}: {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}) => {
+  const $canvas = document.querySelector('#imageReader') as HTMLCanvasElement;
+  $canvas.style.top = `${document.documentElement.scrollTop + top}px`;
+  $canvas.style.left = `${document.documentElement.scrollLeft + left}px`;
+  $canvas.style.zIndex = '999999';
+  $canvas.width = width;
+  $canvas.height = height;
+};
+
+const clearCanvas = () => {
+  const $canvas = document.querySelector('#imageReader') as HTMLCanvasElement;
+  const context = $canvas.getContext('2d');
+  if (!context) return;
+  context.clearRect(0, 0, $canvas.width, $canvas.height);
+  $canvas.width = 0;
+  $canvas.height = 0;
+};
+
+const drawRectCanvas = () => {
+  const $canvas = document.querySelector('#imageReader') as HTMLCanvasElement;
+  const context = $canvas.getContext('2d');
+  if (!context) return;
+
+  context.beginPath();
+  context.rect(0, 0, $canvas.width, $canvas.height);
+  context.lineWidth = 5;
+  context.strokeStyle = 'rgb(255, 255, 0)';
+  context.stroke();
+  context.closePath();
 };
 
 const toggleEventOnBody = () => {
@@ -18,11 +82,13 @@ const toggleEventOnBody = () => {
   if (!$body) return;
 
   chrome.storage.sync.get(({ isSystemRun }) => {
-    console.log(isSystemRun);
+    console.log('Is system run? ' + isSystemRun);
     if (isSystemRun) {
       $body.addEventListener('click', window.onClickBody);
+      createCanvas();
     } else {
       $body.removeEventListener('click', window.onClickBody);
+      removeCanvas();
     }
   });
 };


### PR DESCRIPTION
Feat: 웹 페이지에서 이미지 태그 클릭 시 테두리 그리기 #5

- body에 클릭 이벤트 등록
- 이미지 클릭 시 캔버스를 통해 이미지 주변에 테두리 생성
- 캔버스는 absolute position을 가지며, 이미지의 위치에 따라 캔버스의 top, left가 변경된다.