### PR TITLE
Fix: 드래그 모드 해상도 이슈 수정

### DIFF
--- a/client/src/content/ClickMode.ts
+++ b/client/src/content/ClickMode.ts
@@ -1,6 +1,12 @@
 import debounce from '@utils/debounce';
 import axios from 'axios';
-import { clearRecCanvas, createCanvas, drawRecCanvas, resizeCanvas } from './canvas';
+import {
+  clearRecCanvas,
+  createCanvas,
+  drawRecCanvas,
+  removeCanvas,
+  resizeCanvas,
+} from './canvas';
 import { createOverlay, removeOverlay } from './overlay';
 import { cancelSpeech, speech } from './speech';
 
@@ -65,6 +71,7 @@ const ClickMode = () => {
     const $body = document.querySelector('body');
     if (!$body) return;
     $body.removeEventListener('click', window.onClickBody);
+    removeCanvas({ className: '.clickMode' });
   };
 
   const run = () => {

--- a/client/src/content/DragMode.ts
+++ b/client/src/content/DragMode.ts
@@ -67,14 +67,23 @@ const DragMode = () => {
     port.postMessage({ msg: 'capture' });
     port.onMessage.addListener(({ dataUrl }) => {
       const img = new Image();
+      img.src = dataUrl;
       img.addEventListener('load', async () => {
+        const ratioW = img.width / window.innerWidth;
+        const ratioH = img.height / window.innerHeight;
+
+        const X = x * ratioW;
+        const Y = y * ratioH;
+        const W = w * ratioW;
+        const H = h * ratioH;
+
         const cvs = document.createElement('canvas');
-        cvs.width = w;
-        cvs.height = h;
-        cvs.getContext('2d')?.drawImage(img, x, y, w, h, 0, 0, w, h);
-        const src = cvs.toDataURL('image/jpeg');
+        cvs.width = W;
+        cvs.height = H;
+        cvs.getContext('2d')?.drawImage(img, X, Y, W, H, 0, 0, W, H);
         save(cvs);
 
+        const src = cvs.toDataURL('image/jpeg');
         const formData = new FormData();
         formData.append('imageSrc', src);
 
@@ -95,7 +104,6 @@ const DragMode = () => {
           console.log(e);
         }
       });
-      img.src = dataUrl;
       port.disconnect();
     });
 

--- a/client/src/content/DragMode.ts
+++ b/client/src/content/DragMode.ts
@@ -5,6 +5,7 @@ import {
   clearCanvas,
   createCanvas,
   drawCaptureBoxCanvas,
+  removeCanvas,
   resizeCanvas,
 } from './canvas';
 import { createOverlay, removeOverlay } from './overlay';
@@ -119,6 +120,7 @@ const DragMode = () => {
 
   const exit = () => {
     removeOverlay();
+    removeCanvas({ className: '.dragMode' });
     window.removeEventListener('resize', window.resizeDragMode);
   };
 

--- a/client/src/content/canvas.ts
+++ b/client/src/content/canvas.ts
@@ -1,13 +1,18 @@
 export const createCanvas = ({ type }: { type: string }) => {
-  removeCanvas();
   const $body = document.querySelector('body');
   const $canvas = document.createElement('canvas');
   $canvas.id = 'imageReader';
   $canvas.style.zIndex = '999999';
 
-  if (type === 'CLICK_MODE') $canvas.style.position = 'absolute';
+  if (type === 'CLICK_MODE') {
+    removeCanvas({ className: '.clickMode' });
+    $canvas.className = 'clickMode';
+    $canvas.style.position = 'absolute';
+  }
 
   if (type === 'DRAG_MODE') {
+    removeCanvas({ className: '.dragMode' });
+    $canvas.className = 'dragMode';
     $canvas.style.position = 'fixed';
     $canvas.style.top = '0';
     $canvas.style.left = '0';
@@ -60,9 +65,9 @@ export const clearRecCanvas = () => {
   window.removeEventListener('scroll', window.drawBox);
 };
 
-export const removeCanvas = () => {
+export const removeCanvas = ({ className }: { className: string }) => {
   const $body = document.querySelector('body');
-  const $canvas = document.querySelector('#imageReader');
+  const $canvas = document.querySelector(className);
   if ($canvas) $body?.removeChild($canvas);
 };
 


### PR DESCRIPTION
Fix: 드래그 모드 해상도 이슈 수정

- 드래그 모드에서 사용하는 크롬의 captureVisibleTab() 함수가 현재 화면을 캡쳐한다
- 캡쳐된 이미지의 크기가 window.innerHeight와 같은 크기가 아닌 해상도의 영향을 받음
- 따라서 저장되는 이미지 크기와 window 사이즈를 비교하여 ratio 추춣 후 적용